### PR TITLE
Validation for required fields

### DIFF
--- a/includes/EntityValidateBase.php
+++ b/includes/EntityValidateBase.php
@@ -152,7 +152,7 @@ abstract class EntityValidateBase implements EntityValidateInterface {
 
     if ($silent) {
       // Don't throw an error, and just indicate validation failed.
-      return $errors;
+      return FALSE;
     }
 
     $params = array('@errors' => $errors);
@@ -209,7 +209,7 @@ abstract class EntityValidateBase implements EntityValidateInterface {
     }
 
     if ($return) {
-      return implode("\n\r", $return);
+      return $return;
     }
     else {
       return FALSE;

--- a/includes/EntityValidateBase.php
+++ b/includes/EntityValidateBase.php
@@ -93,11 +93,6 @@ abstract class EntityValidateBase implements EntityValidateInterface {
       );
     }
 
-    // Add all fields.
-    foreach (field_info_instances($this->entityType, $this->bundle) as $field_name => $field_info) {
-      $fields_info[$field_name] = array();
-    }
-
     return $fields_info;
   }
 
@@ -107,11 +102,11 @@ abstract class EntityValidateBase implements EntityValidateInterface {
   public function getFieldsInfo() {
     $fields = $this->setfieldsInfo();
 
-    foreach ($fields as $field_name => $info) {
-      // Loading default value of the fields and the instance.
-      $instance_info = field_info_instance($this->entityType, $field_name, $this->bundle);
-
-      if ($instance_info['required']) {
+    // Add all fields.
+    foreach (field_info_instances($this->entityType, $this->bundle) as $field_name => $info) {
+      $field_info = field_info_field($field_name);
+      $type = $field_info['type'];
+      if ($info['required'] && $type !== 'entityreference') {
         $fields[$field_name]['validators'][] = 'isNotEmpty';
       }
     }

--- a/includes/EntityValidateBase.php
+++ b/includes/EntityValidateBase.php
@@ -105,8 +105,7 @@ abstract class EntityValidateBase implements EntityValidateInterface {
     // Add all fields.
     foreach (field_info_instances($this->entityType, $this->bundle) as $field_name => $info) {
       $field_info = field_info_field($field_name);
-      $type = $field_info['type'];
-      if ($info['required'] && $type !== 'entityreference') {
+      if ($info['required']) {
         $fields[$field_name]['validators'][] = 'isNotEmpty';
       }
     }

--- a/includes/EntityValidateBase.php
+++ b/includes/EntityValidateBase.php
@@ -208,12 +208,7 @@ abstract class EntityValidateBase implements EntityValidateInterface {
       }
     }
 
-    if ($return) {
-      return $return;
-    }
-    else {
-      return FALSE;
-    }
+    return implode("\n\r", $return);
   }
 
   /**

--- a/includes/EntityValidateBase.php
+++ b/includes/EntityValidateBase.php
@@ -93,6 +93,17 @@ abstract class EntityValidateBase implements EntityValidateInterface {
       );
     }
 
+    // Add isNotEmpty validator for every required field.
+    foreach (field_info_instances($this->entityType, $this->bundle) as $field_name => $field_info) {
+      if ($field_info->required) {
+        $fields_info[$field_name] = array(
+          'validators' => array(
+            'isNotEmpty',
+          ),
+        );
+      }
+    }
+
     return $fields_info;
   }
 
@@ -209,7 +220,12 @@ abstract class EntityValidateBase implements EntityValidateInterface {
       }
     }
 
-    return implode("\n\r", $return);
+    if ($return) {
+      return implode("\n\r", $return);
+    }
+    else {
+      return FALSE;
+    }
   }
 
   /**

--- a/includes/EntityValidateBase.php
+++ b/includes/EntityValidateBase.php
@@ -93,15 +93,9 @@ abstract class EntityValidateBase implements EntityValidateInterface {
       );
     }
 
-    // Add isNotEmpty validator for every required field.
+    // Add all fields.
     foreach (field_info_instances($this->entityType, $this->bundle) as $field_name => $field_info) {
-      if ($field_info->required) {
-        $fields_info[$field_name] = array(
-          'validators' => array(
-            'isNotEmpty',
-          ),
-        );
-      }
+      $fields_info[$field_name] = array();
     }
 
     return $fields_info;
@@ -164,7 +158,7 @@ abstract class EntityValidateBase implements EntityValidateInterface {
 
     if ($silent) {
       // Don't throw an error, and just indicate validation failed.
-      return FALSE;
+      return $errors;
     }
 
     $params = array('@errors' => $errors);
@@ -246,6 +240,9 @@ abstract class EntityValidateBase implements EntityValidateInterface {
    * @return boolean
    */
   public function isNotEmpty($field_name, $value) {
+    if (is_array($value) && isset($value['value'])) {
+      $value = $value['value'];
+    }
     if (empty($value)) {
       $params = array(
         '@field' => $field_name,


### PR DESCRIPTION
Add isNotEmpty validator to all required fields.

In addition, return FALSE from `getErrors()` if no errors.
