### PR TITLE
Fix of always required field

### DIFF
--- a/includes/EntityValidateBase.php
+++ b/includes/EntityValidateBase.php
@@ -138,7 +138,7 @@ abstract class EntityValidateBase implements EntityValidateInterface {
       $field_info = field_info_field($field_name);
       $field_type_info = field_info_field_types($field_info['type']);
 
-      if (isset($field_type_info['property_type'])) {
+      if (isset($field_type_info['property_type']) && $wrapper->{$property}->value()) {
         $this->isValidValue($field_name, $wrapper->{$property}->value(), $field_type_info['property_type']);
       }
 

--- a/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
+++ b/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
@@ -15,6 +15,8 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
 
     $fields['title']['validators'][] = 'validateTitleText';
 
+    $fields['field_image']['validators'][] = 'validateIsEmpty';
+
     return $fields;
   }
 
@@ -24,6 +26,15 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
   public function validateTitleText($field_name, $value) {
     if (strlen($value) < 3) {
       $this->setError($field_name, 'The @field should be at least 3 characters long.');
+    }
+  }
+
+  /**
+   * Verify the field is empty.
+   */
+  public function validateIsEmpty($field_name, $value) {
+    if (!empty($value)) {
+      $this->setError($field_name, 'The field @field need to be empty.');
     }
   }
 }

--- a/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
+++ b/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
@@ -30,15 +30,6 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
   }
 
   /**
-   * Verify the field is empty.
-   */
-  public function validateIsEmpty($field_name, $value) {
-    if (!empty($value)) {
-      $this->setError($field_name, 'The field @field need to be empty.');
-    }
-  }
-
-  /**
    * Validate the description has the word "Gizra".
    */
   public function validateBodyText($field_name, $value) {

--- a/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
+++ b/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
@@ -14,8 +14,7 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
     $fields = parent::setFieldsInfo();
 
     $fields['title']['validators'][] = 'validateTitleText';
-
-    $fields['field_image']['validators'][] = 'validateIsEmpty';
+    $fields['field_image']['validators'][] = 'isNotEmpty';
 
     return $fields;
   }

--- a/tests/EntityValidatorTestCase.test
+++ b/tests/EntityValidatorTestCase.test
@@ -45,7 +45,7 @@ class EntityValidatorTestCase extends DrupalWebTestCase {
     $this->assertFalse($result, 'Validate in silent mode did not throw an exception.');
 
     $result = $handler->getErrors(FALSE);
-    $expected_result = array (
+    $expected_result = array(
       'title' => array(
         array(
           'message' => 'The field @field cannot be empty.',
@@ -62,16 +62,17 @@ class EntityValidatorTestCase extends DrupalWebTestCase {
       ),
       'body' => array(
         array(
-          'message' => 'The value @value is invalid for the field @field.',
-          'params' => array(
-            '@value' => '',
-            '@field' => 'body',
-          ),
-        ),
-        array(
           'message' => 'The @field should have the word "Gizra".',
           'params' => array (
             '@field' => 'body',
+          ),
+        ),
+      ),
+      'field_image' => array(
+        array(
+          'message' => 'The field @field cannot be empty.',
+          'params' => array (
+            '@field' => 'field_image',
           ),
         ),
       ),

--- a/tests/EntityValidatorTestCase.test
+++ b/tests/EntityValidatorTestCase.test
@@ -17,6 +17,8 @@ class EntityValidatorTestCase extends DrupalWebTestCase {
 
   function setUp() {
     parent::setUp('entity_validator', 'entity_validator_example');
+
+    $this->drupalCreateContentType(array('name' => 'article'));
   }
 
   /**

--- a/tests/EntityValidatorTestCase.test
+++ b/tests/EntityValidatorTestCase.test
@@ -17,8 +17,6 @@ class EntityValidatorTestCase extends DrupalWebTestCase {
 
   function setUp() {
     parent::setUp('entity_validator', 'entity_validator_example');
-
-    $this->drupalCreateContentType(array('name' => 'article'));
   }
 
   /**


### PR DESCRIPTION
All the fields was required event if it shouldn't be.
for example, an Email field that not required and the value if empty, the error receive is:

``` json
"errors": {
        "email": [
            "The value  is invalid for the field email."
        ],
}
```

So I just added that it should verify if the value is valid only if there is a value.
