### PR TITLE
Module cleanup

### DIFF
--- a/includes/EntityValidateBase.php
+++ b/includes/EntityValidateBase.php
@@ -192,35 +192,6 @@ abstract class EntityValidateBase implements EntityValidateInterface {
   }
 
   /**
-   * Preprocess the field. This is useful when we need to alter a field before
-   * the validation process.
-   *
-   * @param \EntityMetadataWrapper $wrapper
-   *  The wrapper object.
-   * @param string $property_name
-   *  The property name.
-   * @param array $methods
-   *  Array of methods.
-   * @param bool $assign_value
-   *  Determine if we need to assign the from the callback to the field. Default
-   *  to FALSE.
-   */
-  protected function invokeMethods(EntityMetadataWrapper $wrapper, $property_name, array $methods, $assign_value = FALSE) {
-    foreach ($methods as $method) {
-      $property_wrapper = $wrapper->{$property_name};
-
-      $value = $property_wrapper->value();
-      $info = $property_wrapper->info();
-
-      $new_value = $this->{$method}($info['name'], $value, $wrapper);
-      if ($assign_value && $new_value != $value) {
-        // Setting the fields value with the wrapper.
-        $property_wrapper->set($value);
-      }
-    }
-  }
-
-  /**
    * {@inheritdoc}
    */
   public function setError($field_name, $message, $params = array()) {

--- a/includes/EntityValidateBase.php
+++ b/includes/EntityValidateBase.php
@@ -100,13 +100,17 @@ abstract class EntityValidateBase implements EntityValidateInterface {
 
     $instances_info = field_info_instances($this->getEntityType(), $this->getBundle());
     foreach ($instances_info as $instance_info) {
+      $field_info = field_info_field($instance_info['field_name']);
 
       if ($instance_info['required']) {
         // Validate field is not empty.
         $public_fields[$instance_info['field_name']]['required'] = TRUE;
-      }
 
-      $field_info = field_info_field($instance_info['field_name']);
+        // This is a multiple field and required.
+        if ($field_info['cardinality'] == FIELD_CARDINALITY_UNLIMITED) {
+          $public_fields[$instance_info['field_name']]['validators'][] = array($this, 'validateMultipleFieldNotEmpty');
+        }
+      }
 
       if ($field_info['type'] == 'image') {
         // Validate the image dimensions.
@@ -169,11 +173,6 @@ abstract class EntityValidateBase implements EntityValidateInterface {
         if ($public_field['required']) {
           // Property is required.
           $this->isNotEmpty($property, $value, $wrapper, $property_wrapper);
-
-          // This is a multiple field and required.
-          if (method_exists($property_wrapper, 'count') && $property_wrapper->count() > 1) {
-            $this->validateMultipleFieldNotEmpty($property, $value, $wrapper, $property_wrapper);
-          }
         }
 
         if ($value && $validator) {

--- a/includes/EntityValidateBase.php
+++ b/includes/EntityValidateBase.php
@@ -390,7 +390,7 @@ abstract class EntityValidateBase implements EntityValidateInterface {
   }
 
   /**
-   * Validate population of the multiple field with info.
+   * Validate a field with multiple cardinality is not empty.
    *
    * @param string $field_name
    *   The field name.
@@ -404,7 +404,7 @@ abstract class EntityValidateBase implements EntityValidateInterface {
   public function validateMultipleFieldNotEmpty($field_name, $value, EntityMetadataWrapper $wrapper, EntityMetadataWrapper $property_wrapper) {
     foreach ($property_wrapper as $delta => $sub_wrapper) {
       if (!$sub_wrapper->value()) {
-        $this->setError($field_name, 'The delta @delta cant be empty', array('@delta' => $delta));
+        $this->setError($field_name, 'The delta @delta cannot be empty.', array('@delta' => $delta));
       }
     }
   }

--- a/includes/EntityValidateBase.php
+++ b/includes/EntityValidateBase.php
@@ -137,6 +137,8 @@ abstract class EntityValidateBase implements EntityValidateInterface {
         'validators' => array($this, 'isValidValue'),
       );
     }
+
+    return $public_fields;
   }
 
   /**

--- a/includes/EntityValidateBase.php
+++ b/includes/EntityValidateBase.php
@@ -110,12 +110,12 @@ abstract class EntityValidateBase implements EntityValidateInterface {
 
       if ($field_info['type'] == 'image') {
         // Validate the image dimensions.
-        $public_fields[$instance_info['field_name']]['validators'][] = 'validateImageSize';
+        $public_fields[$instance_info['field_name']]['validators'][] = array($this, 'validateImageSize');
       }
 
       if (in_array($field_info['type'], array('image', 'file'))) {
         // Validate the file type.
-        $public_fields[$instance_info['field_name']]['validators'][] = 'validateFileExtension';
+        $public_fields[$instance_info['field_name']]['validators'][] = array($this, 'validateFileExtension');
       }
     }
 
@@ -134,7 +134,7 @@ abstract class EntityValidateBase implements EntityValidateInterface {
         'property' => $property,
         'sub_property',
         'required' => FALSE,
-        'validators' => array('isValidValue'),
+        'validators' => array($this, 'isValidValue'),
       );
     }
   }

--- a/includes/EntityValidateBase.php
+++ b/includes/EntityValidateBase.php
@@ -333,7 +333,7 @@ abstract class EntityValidateBase implements EntityValidateInterface {
       }
 
       if ($value['height'] > $max_height) {
-        $this->setError($field_name, 'The width of the image(@height) is bigger then the allowed size(@max-height)', $params);
+        $this->setError($field_name, 'The height of the image(@height) is bigger then the allowed size(@max-height)', $params);
       }
     }
 
@@ -349,7 +349,7 @@ abstract class EntityValidateBase implements EntityValidateInterface {
       }
 
       if ($value['height'] < $min_height) {
-        $this->setError($field_name, 'The width of the image(@height) is bigger then the allowed size(@min-height)', $params);
+        $this->setError($field_name, 'The height of the image(@height) is bigger then the allowed size(@min-height)', $params);
       }
     }
   }

--- a/includes/EntityValidateBase.php
+++ b/includes/EntityValidateBase.php
@@ -228,7 +228,7 @@ abstract class EntityValidateBase implements EntityValidateInterface {
    *
    * @param string $field_name
    *  The field name.
-   * @param mix $value
+   * @param mixed $value
    *  The value of the field.
    * @param EntityMetadataWrapper $wrapper
    *   The wrapped entity.
@@ -247,7 +247,7 @@ abstract class EntityValidateBase implements EntityValidateInterface {
    *
    * @param string $field_name
    *  The field name.
-   * @param mix $value
+   * @param mixed $value
    *  The value of the field.
    * @param EntityMetadataWrapper $wrapper
    *   The wrapped entity.
@@ -285,7 +285,7 @@ abstract class EntityValidateBase implements EntityValidateInterface {
    *
    * @param string $field_name
    *  The field name.
-   * @param mix $value
+   * @param mixed $value
    *  The value of the field.
    * @param EntityMetadataWrapper $wrapper
    *   The wrapped entity.
@@ -353,7 +353,7 @@ abstract class EntityValidateBase implements EntityValidateInterface {
    *
    * @param string $field_name
    *  The field name.
-   * @param mix $value
+   * @param mixed $value
    *  The value of the field.
    * @param EntityMetadataWrapper $wrapper
    *   The wrapped entity.

--- a/includes/EntityValidateBase.php
+++ b/includes/EntityValidateBase.php
@@ -169,9 +169,14 @@ abstract class EntityValidateBase implements EntityValidateInterface {
         if ($public_field['required']) {
           // Property is required.
           $this->isNotEmpty($property, $value, $wrapper, $property_wrapper);
+
+          // This is a multiple field and required.
+          if (method_exists($property_wrapper, 'count') && $property_wrapper->count() > 1) {
+            $this->validateMultipleFieldNotEmpty($property, $value, $wrapper, $property_wrapper);
+          }
         }
 
-        if ($value) {
+        if ($value && $validator) {
           // Property has value.
           call_user_func($validator, $property, $value, $wrapper, $property_wrapper);
         }
@@ -382,6 +387,26 @@ abstract class EntityValidateBase implements EntityValidateInterface {
         '@extensions' => $settings['file_extensions'],
       );
       $this->setError($field_name, 'The file (@file-name) extension (@extension) did not match the allowed extensions: @extensions', $params);
+    }
+  }
+
+  /**
+   * Validate population of the multiple field with info.
+   *
+   * @param string $field_name
+   *   The field name.
+   * @param mixed $value
+   *   The value of the field.
+   * @param EntityMetadataWrapper $wrapper
+   *   The wrapped entity.
+   * @param EntityMetadataWrapper $property_wrapper
+   *   The wrapped property.
+   */
+  public function validateMultipleFieldNotEmpty($field_name, $value, EntityMetadataWrapper $wrapper, EntityMetadataWrapper $property_wrapper) {
+    foreach ($property_wrapper as $delta => $sub_wrapper) {
+      if (!$sub_wrapper->value()) {
+        $this->setError($field_name, 'The delta @delta cant be empty', array('@delta' => $delta));
+      }
     }
   }
 }

--- a/includes/EntityValidateBase.php
+++ b/includes/EntityValidateBase.php
@@ -160,7 +160,7 @@ abstract class EntityValidateBase implements EntityValidateInterface {
       foreach ($public_field['validators'] as $validator) {
         $property_wrapper = $wrapper->{$property};
 
-        if ($public_field['sub_property']) {
+        if (!empty($public_field['sub_property']) && $property_wrapper->value()) {
           $property_wrapper = $property_wrapper->{$public_field['sub_property']};
         }
 

--- a/includes/EntityValidateBase.php
+++ b/includes/EntityValidateBase.php
@@ -175,7 +175,7 @@ abstract class EntityValidateBase implements EntityValidateInterface {
           $this->isNotEmpty($property, $value, $wrapper, $property_wrapper);
         }
 
-        if ($value && $validator) {
+        if ($validator) {
           // Property has value.
           call_user_func($validator, $property, $value, $wrapper, $property_wrapper);
         }
@@ -233,9 +233,9 @@ abstract class EntityValidateBase implements EntityValidateInterface {
    * Verify the field is not empty.
    *
    * @param string $field_name
-   *  The field name.
+   *   The field name.
    * @param mixed $value
-   *  The value of the field.
+   *   The value of the field.
    * @param EntityMetadataWrapper $wrapper
    *   The wrapped entity.
    * @param EntityMetadataWrapper $property_wrapper
@@ -252,9 +252,9 @@ abstract class EntityValidateBase implements EntityValidateInterface {
    * Check the value of the field using the entity API module.
    *
    * @param string $field_name
-   *  The field name.
+   *   The field name.
    * @param mixed $value
-   *  The value of the field.
+   *   The value of the field.
    * @param EntityMetadataWrapper $wrapper
    *   The wrapped entity.
    * @param EntityMetadataWrapper $property_wrapper
@@ -290,9 +290,9 @@ abstract class EntityValidateBase implements EntityValidateInterface {
    * Validate the field image's by checking the image size is valid.
    *
    * @param string $field_name
-   *  The field name.
+   *   The field name.
    * @param mixed $value
-   *  The value of the field.
+   *   The value of the field.
    * @param EntityMetadataWrapper $wrapper
    *   The wrapped entity.
    * @param EntityMetadataWrapper $property_wrapper
@@ -358,9 +358,9 @@ abstract class EntityValidateBase implements EntityValidateInterface {
    * Validate the file extension.
    *
    * @param string $field_name
-   *  The field name.
+   *   The field name.
    * @param mixed $value
-   *  The value of the field.
+   *   The value of the field.
    * @param EntityMetadataWrapper $wrapper
    *   The wrapped entity.
    * @param EntityMetadataWrapper $property_wrapper

--- a/includes/EntityValidateBase.php
+++ b/includes/EntityValidateBase.php
@@ -235,7 +235,7 @@ abstract class EntityValidateBase implements EntityValidateInterface {
    * @param EntityMetadataWrapper $property_wrapper
    *   The wrapped property.
    */
-  public function isNotEmpty($field_name, $value, EntityMetadataWrapper $wrapper, EntityMetadataWrapper $property_wrapper) {
+  protected function isNotEmpty($field_name, $value, EntityMetadataWrapper $wrapper, EntityMetadataWrapper $property_wrapper) {
     if (empty($value)) {
       $params = array('@field' => $field_name);
       $this->setError($field_name, 'The field @field cannot be empty.', $params);
@@ -254,7 +254,7 @@ abstract class EntityValidateBase implements EntityValidateInterface {
    * @param EntityMetadataWrapper $property_wrapper
    *   The wrapped property.
    */
-  public function isValidValue($field_name, $value, EntityMetadataWrapper $wrapper, EntityMetadataWrapper $property_wrapper) {
+  protected function isValidValue($field_name, $value, EntityMetadataWrapper $wrapper, EntityMetadataWrapper $property_wrapper) {
     // Loading default value of the fields and the instance.
     if (!$field_info = field_info_field($field_name)) {
       // Not a field.
@@ -281,14 +281,18 @@ abstract class EntityValidateBase implements EntityValidateInterface {
   }
 
   /**
-   * Validate the field image: Check the image is the correct size.
+   * Validate the field image's by checking the image size is valid.
    *
-   * @param $field_name
+   * @param string $field_name
    *  The field name.
-   * @param $value
+   * @param mix $value
    *  The value of the field.
+   * @param EntityMetadataWrapper $wrapper
+   *   The wrapped entity.
+   * @param EntityMetadataWrapper $property_wrapper
+   *   The wrapped property.
    */
-  public function validateImageSize($field_name, $value) {
+  protected function validateImageSize($field_name, $value, EntityMetadataWrapper $wrapper, EntityMetadataWrapper $property_wrapper) {
     if (empty($value)) {
       return;
     }
@@ -345,14 +349,18 @@ abstract class EntityValidateBase implements EntityValidateInterface {
   }
 
   /**
-   * Validating the file extension.
+   * Validate the file extension.
    *
-   * @param $field_name
+   * @param string $field_name
    *  The field name.
-   * @param $value
+   * @param mix $value
    *  The value of the field.
+   * @param EntityMetadataWrapper $wrapper
+   *   The wrapped entity.
+   * @param EntityMetadataWrapper $property_wrapper
+   *   The wrapped property.
    */
-  public function validateFileExtension($field_name, $value) {
+  protected function validateFileExtension($field_name, $value, EntityMetadataWrapper $wrapper, EntityMetadataWrapper $property_wrapper) {
     if (empty($value)) {
       return;
     }

--- a/includes/EntityValidateInterface.php
+++ b/includes/EntityValidateInterface.php
@@ -49,7 +49,6 @@ interface EntityValidateInterface {
    */
   public function publicFieldsInfo();
 
-
   /**
    *
    * Return the processed array with the field validation declarations.

--- a/includes/EntityValidateInterface.php
+++ b/includes/EntityValidateInterface.php
@@ -14,7 +14,7 @@ interface EntityValidateInterface {
    * Set the bundle of the node.
    *
    * @param $bundle
-   *  The bundle machine name.
+   *   The bundle machine name.
    *
    * @return $this
    */
@@ -29,7 +29,7 @@ interface EntityValidateInterface {
    * Set the entity type.
    *
    * @param $entity
-   *  The name of the entity.
+   *   The name of the entity.
    *
    * @return $this
    */
@@ -52,7 +52,7 @@ interface EntityValidateInterface {
 
   /**
    *
-   * Return the processed array with the field validation declerations.
+   * Return the processed array with the field validation declarations.
    *
    * @return array
    */
@@ -62,10 +62,10 @@ interface EntityValidateInterface {
    * Initialize the validate process.
    *
    * @param $entity
-   *  The entity we need to validate.
+   *   The entity we need to validate.
    * @param $silent
-   *  Determine if we throw the exception or return array with the errors.
-   *  Defaults to FALSE.
+   *   Determine if we throw the exception or return array with the errors.
+   *   Defaults to FALSE.
    *
    * @throws EntityValidatorException
    */
@@ -75,23 +75,23 @@ interface EntityValidateInterface {
    * Set error.
    *
    * @param $field_name
-   *  The name of the field.
+   *   The name of the field.
    * @param $message
-   *  Set the error message without wrapping the text with t().
+   *   Set the error message without wrapping the text with t().
    * @param $params
-   *  Optional. The parameters for the t() function.
+   *   Optional. The parameters for the t() function.
    *
    * @throws Exception
-   *  When setting the error level to 1 exception will be thrown with the value
-   *  of the error.
+   *   When setting the error level to 1 exception will be thrown with the value
+   *   of the error.
    *
    * @code
-   *  $params = array(
-   *    '@value' => 'foo',
-   *    '@field' => 'date',
-   *  );
-   *  $this->setError('field_date', 'The value @value is invalid for the field @field', $params);
-   *  $this->setError('title', 'The node must have a title');
+   *   $params = array(
+   *     '@value' => 'foo',
+   *     '@field' => 'date',
+   *   );
+   *   $this->setError('field_date', 'The value @value is invalid for the field @field', $params);
+   *   $this->setError('title', 'The node must have a title');
    * @endcode
    */
   public function setError($field_name, $message, $params = '');
@@ -105,7 +105,7 @@ interface EntityValidateInterface {
    *   TRUE.
    *
    * @return Array
-   *  Return the errors which occurred during the validation process.
+   *   Return the errors which occurred during the validation process.
    */
   public function getErrors($squash = TRUE);
 

--- a/includes/EntityValidateInterface.php
+++ b/includes/EntityValidateInterface.php
@@ -43,11 +43,20 @@ interface EntityValidateInterface {
   public function getEntityType();
 
   /**
-   * Set the field validate and preprocess methods.
+   * Return array with the field validate and preprocess methods.
    *
-   * @return Array.
+   * @return array
    */
-  public function getFieldsInfo();
+  public function publicFieldsInfo();
+
+
+  /**
+   *
+   * Return the processed array with the field validation declerations.
+   *
+   * @return array
+   */
+  public function getPublicFields();
 
   /**
    * Initialize the validate process.

--- a/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
+++ b/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
@@ -13,7 +13,7 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
   public function publicFieldsInfo() {
     $public_fields = parent::publicFieldsInfo();
 
-    $public_fields['title']['validators'][] = 'validateTitleText';
+    $public_fields['title']['validators'][] = array($this, 'validateBodyText');
 
     $public_fields['body'] = array(
       'required' => TRUE,

--- a/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
+++ b/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
@@ -28,8 +28,17 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
 
   /**
    * Validate the title is at least 3 characters long.
+   *
+   * @param string $field_name
+   *  The field name.
+   * @param mix $value
+   *  The value of the field.
+   * @param EntityMetadataWrapper $wrapper
+   *   The wrapped entity.
+   * @param EntityMetadataWrapper $property_wrapper
+   *   The wrapped property.
    */
-  public function validateTitleText($field_name, $value) {
+  public function validateTitleText($field_name, $value, EntityMetadataWrapper $wrapper, EntityMetadataWrapper $property_wrapper) {
     if (strlen($value) < 3) {
       $this->setError($field_name, 'The @field should be at least 3 characters long.');
     }
@@ -37,8 +46,17 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
 
   /**
    * Validate the description has the word "Drupal".
+   *
+   * @param string $field_name
+   *  The field name.
+   * @param mix $value
+   *  The value of the field.
+   * @param EntityMetadataWrapper $wrapper
+   *   The wrapped entity.
+   * @param EntityMetadataWrapper $property_wrapper
+   *   The wrapped property.
    */
-  public function validateBodyText($field_name, $value) {
+  public function validateBodyText($field_name, $value, EntityMetadataWrapper $wrapper, EntityMetadataWrapper $property_wrapper) {
     if (strpos($value, 'Drupal') === FALSE) {
       $this->setError($field_name, 'The @field should have the word "Drupal".');
     }

--- a/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
+++ b/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
@@ -24,7 +24,7 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
     );
 
     $public_fields['field_text_multiple'] = array(
-      array($this, 'validateMultipleField'),
+      'validators' => array($this, 'validateMultipleField'),
     );
 
     return $public_fields;
@@ -81,7 +81,7 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
    */
   public function validateMultipleField($field_name, $value, EntityMetadataWrapper $wrapper, EntityMetadataWrapper $property_wrapper) {
     foreach ($wrapper as $sub_wrapper) {
-      debug($wrapper->value());
+      debug($sub_wrapper->value());
     }
   }
 }

--- a/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
+++ b/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
@@ -30,9 +30,9 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
    * Validate the title is at least 3 characters long.
    *
    * @param string $field_name
-   *  The field name.
+   *   The field name.
    * @param mixed $value
-   *  The value of the field.
+   *   The value of the field.
    * @param EntityMetadataWrapper $wrapper
    *   The wrapped entity.
    * @param EntityMetadataWrapper $property_wrapper
@@ -48,9 +48,9 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
    * Validate the description has the word "Drupal".
    *
    * @param string $field_name
-   *  The field name.
+   *   The field name.
    * @param mixed $value
-   *  The value of the field.
+   *   The value of the field.
    * @param EntityMetadataWrapper $wrapper
    *   The wrapped entity.
    * @param EntityMetadataWrapper $property_wrapper

--- a/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
+++ b/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
@@ -23,11 +23,8 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
       ),
     );
 
-    $public_fields['field_text_multiple'] = array(
-      'validators' => array(
-        array($this, 'validateMultipleField'),
-      ),
-    );
+    // todo: multiple required fields don't need to be defined.
+    $public_fields['field_text_multiple']['validators'][] = array($this, 'validateBodyText');
 
     return $public_fields;
   }
@@ -68,24 +65,4 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
     }
   }
 
-  /**
-   * Validate the multiple field is populated with info and not left with empty
-   * values.
-   *
-   * @param string $field_name
-   *   The field name.
-   * @param mixed $value
-   *   The value of the field.
-   * @param EntityMetadataWrapper $wrapper
-   *   The wrapped entity.
-   * @param EntityMetadataWrapper $property_wrapper
-   *   The wrapped property.
-   */
-  public function validateMultipleField($field_name, $value, EntityMetadataWrapper $wrapper, EntityMetadataWrapper $property_wrapper) {
-    foreach ($property_wrapper as $delta => $sub_wrapper) {
-      if (!$sub_wrapper->value()) {
-        $this->setError($field_name, 'The delta @delta cant be empty', array('@delta' => $delta));
-      }
-    }
-  }
 }

--- a/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
+++ b/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
@@ -23,6 +23,10 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
       ),
     );
 
+    $public_fields['field_text_multiple'] = array(
+      array($this, 'validateMultipleField'),
+    );
+
     return $public_fields;
   }
 
@@ -59,6 +63,25 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
   public function validateBodyText($field_name, $value, EntityMetadataWrapper $wrapper, EntityMetadataWrapper $property_wrapper) {
     if (strpos($value, 'Drupal') === FALSE) {
       $this->setError($field_name, 'The @field should have the word "Drupal".');
+    }
+  }
+
+  /**
+   * Validate the multiple field is populated with info and not left with empty
+   * values.
+   *
+   * @param string $field_name
+   *   The field name.
+   * @param mixed $value
+   *   The value of the field.
+   * @param EntityMetadataWrapper $wrapper
+   *   The wrapped entity.
+   * @param EntityMetadataWrapper $property_wrapper
+   *   The wrapped property.
+   */
+  public function validateMultipleField($field_name, $value, EntityMetadataWrapper $wrapper, EntityMetadataWrapper $property_wrapper) {
+    foreach ($wrapper as $sub_wrapper) {
+      debug($wrapper->value());
     }
   }
 }

--- a/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
+++ b/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
@@ -24,7 +24,9 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
     );
 
     $public_fields['field_text_multiple'] = array(
-      'validators' => array($this, 'validateMultipleField'),
+      'validators' => array(
+        array($this, 'validateMultipleField'),
+      ),
     );
 
     return $public_fields;
@@ -80,8 +82,10 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
    *   The wrapped property.
    */
   public function validateMultipleField($field_name, $value, EntityMetadataWrapper $wrapper, EntityMetadataWrapper $property_wrapper) {
-    foreach ($wrapper as $sub_wrapper) {
-      debug($sub_wrapper->value());
+    foreach ($property_wrapper as $delta => $sub_wrapper) {
+      if (!$sub_wrapper->value()) {
+        $this->setError($field_name, 'The delta @delta cant be empty', array('@delta' => $delta));
+      }
     }
   }
 }

--- a/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
+++ b/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
@@ -19,7 +19,7 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
       'required' => TRUE,
       'sub_property' => 'value',
       'validators' => array(
-        'validateBodyText'
+        array($this, 'validateBodyText')
       ),
     );
 

--- a/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
+++ b/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
@@ -31,7 +31,7 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
    *
    * @param string $field_name
    *  The field name.
-   * @param mix $value
+   * @param mixed $value
    *  The value of the field.
    * @param EntityMetadataWrapper $wrapper
    *   The wrapped entity.
@@ -49,7 +49,7 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
    *
    * @param string $field_name
    *  The field name.
-   * @param mix $value
+   * @param mixed $value
    *  The value of the field.
    * @param EntityMetadataWrapper $wrapper
    *   The wrapped entity.

--- a/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
+++ b/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
@@ -8,15 +8,22 @@
 class EntityValidatorExampleArticleValidator extends EntityValidateBase {
 
   /**
-   * Overrides EntityValidateBase::getFieldsInfo().
+   * Overrides EntityValidateBase::publicFieldsInfo().
    */
-  public function getFieldsInfo() {
-    $fields = parent::getFieldsInfo();
+  public function publicFieldsInfo() {
+    $public_fields = parent::publicFieldsInfo();
 
-    $fields['title']['validators'][] = 'validateTitleText';
-    $fields['body']['validators'][] = 'validateBodyText';
+    $public_fields['title']['validators'][] = 'validateTitleText';
 
-    return $fields;
+    $public_fields['body'] = array(
+      'required' => TRUE,
+      'sub_property' => 'value',
+      'validators' => array(
+        'validateBodyText'
+      ),
+    );
+
+    return $public_fields;
   }
 
   /**
@@ -29,10 +36,10 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
   }
 
   /**
-   * Validate the description has the word "Gizra".
+   * Validate the description has the word "Drupal".
    */
   public function validateBodyText($field_name, $value) {
-    if (empty($value['value']) || strpos($value['value'], 'Drupal') === FALSE) {
+    if (strpos($value, 'Drupal') === FALSE) {
       $this->setError($field_name, 'The @field should have the word "Drupal".');
     }
   }

--- a/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
+++ b/modules/entity_validator_example/plugins/validator/node/article/EntityValidatorExampleArticleValidator.class.php
@@ -23,9 +23,6 @@ class EntityValidatorExampleArticleValidator extends EntityValidateBase {
       ),
     );
 
-    // todo: multiple required fields don't need to be defined.
-    $public_fields['field_text_multiple']['validators'][] = array($this, 'validateBodyText');
-
     return $public_fields;
   }
 

--- a/tests/EntityValidatorTestCase.test
+++ b/tests/EntityValidatorTestCase.test
@@ -39,13 +39,13 @@ class EntityValidatorTestCase extends DrupalWebTestCase {
     $field = array(
       'field_name' => 'field_text_multiple',
       'type' => 'text',
+      'cardinality' => FIELD_CARDINALITY_UNLIMITED,
     );
     field_create_field($field);
 
     $instance = array(
       'entity_type' => 'node',
       'bundle' => 'article',
-      'cardinality' => FIELD_CARDINALITY_UNLIMITED,
       'field_name' => 'field_text_multiple',
       'widget' => array(
         'type' => 'textfield',
@@ -58,10 +58,12 @@ class EntityValidatorTestCase extends DrupalWebTestCase {
    * Test the validation on an entity.
    */
   function testValidate() {
+    $value[] = array('value' => 'a', 'format' => 'full_html');
+    $value[] = array('value' => 'a', 'format' => 'full_html');
+    $value[] = array('value' => 'a', 'format' => 'full_html');
+    $value[] = array();
     $file = $this->createImage();
-    $text_multiple[] = array('value' => 'First row');
-    $text_multiple[] = array('value' => 'Second row');
-    $text_multiple[] = array('value' => '');
+
     $values = array(
       'type' => 'article',
       'uid' => 0,
@@ -70,7 +72,7 @@ class EntityValidatorTestCase extends DrupalWebTestCase {
     $handler = entity_validator_get_validator_handler('node', 'article');
     $wrapper = entity_metadata_wrapper('node', $node);
     $wrapper->field_image->set(array('fid' => $file->fid));
-    $wrapper->field_text_multiple->set();
+    $wrapper->field_text_multiple->set($value);
 
     try {
       $handler->validate($node);

--- a/tests/EntityValidatorTestCase.test
+++ b/tests/EntityValidatorTestCase.test
@@ -59,9 +59,9 @@ class EntityValidatorTestCase extends DrupalWebTestCase {
    * Test the validation on an entity.
    */
   function testValidate() {
-    $value[] = array('value' => 'a', 'format' => 'full_html');
-    $value[] = array('value' => 'a', 'format' => 'full_html');
-    $value[] = array('value' => 'a', 'format' => 'full_html');
+    $value[] = array('value' => 'First value', 'format' => 'full_html');
+    $value[] = array('value' => 'Second value', 'format' => 'full_html');
+    $value[] = array('value' => 'Third value', 'format' => 'full_html');
     $value[] = array();
     $file = $this->createImage();
 

--- a/tests/EntityValidatorTestCase.test
+++ b/tests/EntityValidatorTestCase.test
@@ -34,6 +34,24 @@ class EntityValidatorTestCase extends DrupalWebTestCase {
     );
 
     field_update_instance($instance);
+
+    // Add multiple field.
+    $field = array(
+      'field_name' => 'field_text_multiple',
+      'type' => 'text',
+    );
+    field_create_field($field);
+
+    $instance = array(
+      'entity_type' => 'node',
+      'bundle' => 'article',
+      'cardinality' => FIELD_CARDINALITY_UNLIMITED,
+      'field_name' => 'field_text_multiple',
+      'widget' => array(
+        'type' => 'textfield',
+      ),
+    );
+    field_create_instance($instance);
   }
 
   /**
@@ -41,6 +59,9 @@ class EntityValidatorTestCase extends DrupalWebTestCase {
    */
   function testValidate() {
     $file = $this->createImage();
+    $text_multiple[] = array('value' => 'First row');
+    $text_multiple[] = array('value' => 'Second row');
+    $text_multiple[] = array('value' => '');
     $values = array(
       'type' => 'article',
       'uid' => 0,
@@ -49,6 +70,7 @@ class EntityValidatorTestCase extends DrupalWebTestCase {
     $handler = entity_validator_get_validator_handler('node', 'article');
     $wrapper = entity_metadata_wrapper('node', $node);
     $wrapper->field_image->set(array('fid' => $file->fid));
+    $wrapper->field_text_multiple->set();
 
     try {
       $handler->validate($node);

--- a/tests/EntityValidatorTestCase.test
+++ b/tests/EntityValidatorTestCase.test
@@ -98,6 +98,12 @@ class EntityValidatorTestCase extends DrupalWebTestCase {
             '@field' => 'title',
           ),
         ),
+        array(
+          'message' => 'The @field should have the word "Drupal".',
+          'params' => array(
+            '@field' => 'title',
+          ),
+        ),
       ),
       'field_image' => array(
         array(
@@ -111,7 +117,7 @@ class EntityValidatorTestCase extends DrupalWebTestCase {
           ),
         ),
         array(
-          'message' => 'The width of the image(@height) is bigger then the allowed size(@min-height)',
+          'message' => 'The height of the image(@height) is bigger then the allowed size(@min-height)',
           'params' => array(
             '@width' => 40,
             '@height' => 20,
@@ -132,20 +138,26 @@ class EntityValidatorTestCase extends DrupalWebTestCase {
           ),
         ),
       ),
-      'body' => array(
-        array(
-          'message' => 'The field @field cannot be empty.',
-          'params' =>  array(
-            '@field' => 'body',
-          ),
-        ),
-      ),
       'field_text_multiple' => array(
         array(
           'message' => 'The delta @delta cant be empty',
           'params' => array(
             '@delta' => 3,
             '@field' => 'field_text_multiple',
+          ),
+        ),
+      ),
+      'body' => array(
+        array(
+          'message' => 'The field @field cannot be empty.',
+          'params' => array(
+            '@field' => 'body',
+          ),
+        ),
+        array(
+          'message' => 'The @field should have the word "Drupal".',
+          'params' => array(
+            '@field' => 'body',
           ),
         ),
       ),

--- a/tests/EntityValidatorTestCase.test
+++ b/tests/EntityValidatorTestCase.test
@@ -140,7 +140,7 @@ class EntityValidatorTestCase extends DrupalWebTestCase {
       ),
       'field_text_multiple' => array(
         array(
-          'message' => 'The delta @delta cant be empty',
+          'message' => 'The delta @delta cannot be empty.',
           'params' => array(
             '@delta' => 3,
             '@field' => 'field_text_multiple',

--- a/tests/EntityValidatorTestCase.test
+++ b/tests/EntityValidatorTestCase.test
@@ -73,20 +73,6 @@ class EntityValidatorTestCase extends DrupalWebTestCase {
             '@field' => 'title',
           ),
         ),
-        array(
-          'message' => 'The @field should be at least 3 characters long.',
-          'params' => array(
-            '@field' => 'title',
-          ),
-        ),
-      ),
-      'body' => array(
-        array(
-          'message' => 'The @field should have the word "Drupal".',
-          'params' => array (
-            '@field' => 'body',
-          ),
-        ),
       ),
       'field_image' => array(
         array(
@@ -113,11 +99,19 @@ class EntityValidatorTestCase extends DrupalWebTestCase {
         ),
         array(
           'message' => 'The file (@file-name) extension (@extension) did not match the allowed extensions: @extensions',
-          'params' => array (
+          'params' => array(
             '@file-name' => 'image-test.png',
             '@extension' => 'png',
             '@extensions' => 'pdf',
             '@field' => 'field_image',
+          ),
+        ),
+      ),
+      'body' => array(
+        array(
+          'message' => 'The field @field cannot be empty.',
+          'params' =>  array(
+            '@field' => 'body',
           ),
         ),
       ),

--- a/tests/EntityValidatorTestCase.test
+++ b/tests/EntityValidatorTestCase.test
@@ -139,6 +139,15 @@ class EntityValidatorTestCase extends DrupalWebTestCase {
           ),
         ),
       ),
+      'field_text_multiple' => array(
+        array(
+          'message' => 'The delta @delta cant be empty',
+          'params' => array(
+            '@delta' => 3,
+            '@field' => 'field_text_multiple',
+          ),
+        ),
+      ),
     );
     $this->assertEqual($result, $expected_result, 'The silent mode returned the expected results.');
   }

--- a/tests/EntityValidatorTestCase.test
+++ b/tests/EntityValidatorTestCase.test
@@ -47,6 +47,7 @@ class EntityValidatorTestCase extends DrupalWebTestCase {
       'entity_type' => 'node',
       'bundle' => 'article',
       'field_name' => 'field_text_multiple',
+      'required' => TRUE,
       'widget' => array(
         'type' => 'textfield',
       ),


### PR DESCRIPTION
Still WIP, and completely un-tested ;)
- [ ] Make methods similar to RESTful
- [ ] Remove preprocess -- it's not up for this module to change the field value. What was the original use case?
- [ ] Pass more arguments to the validate callbacks, and allow passing sub_property (e.g. $wrapper->body->value) instead of the whole value array.

@RoySegall @mateu-aguilo-bosch
Next is some cleanup for the name property/ field_name -- although I'm not sure which one is the correct one
